### PR TITLE
Fix crash on ios when foregrounding app on device

### DIFF
--- a/ios/JBBaseTextShadowView.m
+++ b/ios/JBBaseTextShadowView.m
@@ -89,7 +89,7 @@ static void RCTInlineViewYogaNodeDirtied(YGNodeRef node)
   NSMutableAttributedString *attributedText = [NSMutableAttributedString new];
 
   [attributedText beginEditing];
-  if (_textAttributes.text) {
+  if (_textAttributes.text && _textAttributes.text.length > 0) {
     NSAttributedString *rawTextAttributedString =
       [[NSAttributedString alloc] initWithString:[textAttributes applyTextAttributesToText:_textAttributes.text] attributes:textAttributes.effectiveTextAttributes];
     [attributedText appendAttributedString:rawTextAttributedString];


### PR DESCRIPTION
This additional check will fix the crash when going from background to foreground when running on device (does not happen when using simulator)