### PR TITLE
feat: Add React Native 0.66 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,15 @@ A fork of React Native's `<Text/>` component that supports Animated Values as te
     <th>RN Version</th>
   </tr>
   <tr>
-    <td> ^0.7.0 </td>
+    <td> ^0.8.0</td>
+    <td> ^0.66</td>
+  </tr>
+  <tr>
+    <td> ^0.7.0</td>
     <td> ^0.65</td>
   </tr>
   <tr>
-    <td> ^0.6.0 </td>
+    <td> ^0.6.0</td>
     <td> ^0.64</td>
   </tr>
   <tr>

--- a/android/src/main/java/com/reactnativereanimatedtext/JBTextShadowNode.java
+++ b/android/src/main/java/com/reactnativereanimatedtext/JBTextShadowNode.java
@@ -22,7 +22,7 @@ import androidx.annotation.Nullable;
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactNoCrashSoftException;
-import com.facebook.react.bridge.ReactSoftException;
+import com.facebook.react.bridge.ReactSoftExceptionLogger;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.uimanager.NativeViewHierarchyOptimizer;
@@ -121,7 +121,7 @@ public class JBTextShadowNode extends JBBaseTextShadowNode {
               .getJSModule(RCTEventEmitter.class)
               .receiveEvent(getReactTag(), "topTextLayout", event);
           } else {
-            ReactSoftException.logSoftException(
+            ReactSoftExceptionLogger.logSoftException(
               "ReactTextShadowNode",
               new ReactNoCrashSoftException("Cannot get RCTEventEmitter, no CatalystInstance"));
           }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-animateable-text",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "A fork of React Native's <Text/> component that supports Animated Values",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
On React Native 0.66, `ReactSoftException` has been renamed to `ReactSoftExceptionLogger`.
This commit fixes the usage of that name and makes the library compatible with React Native 0.66.

This breaks the build for projects below React Native 0.66!

* Fixes #22