### PR TITLE
fix: use React-Core instead of React

### DIFF
--- a/react-native-animateable-text.podspec
+++ b/react-native-animateable-text.podspec
@@ -17,5 +17,5 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm}"
 
 
-  s.dependency "React"
+  s.dependency "React-Core"
 end


### PR DESCRIPTION
We should use `React-Core` instead of `React` according to https://github.com/facebook/react-native/issues/29633#issuecomment-694187116