### PR TITLE
fix: update React import for Expo 44

### DIFF
--- a/ios/JBTextShadowView.m
+++ b/ios/JBTextShadowView.m
@@ -12,7 +12,7 @@
 #import <React/RCTUIManager.h>
 #import <yoga/Yoga.h>
 
-#import "NSTextStorage+FontScaling.h"
+#import <React/NSTextStorage+FontScaling.h>
 #import <React/RCTTextView.h>
 
 @implementation JBTextShadowView


### PR DESCRIPTION
This updates the import style for React Native headers so it can be used with Expo 44. Any project will SDK 44 will fail to build without this change.
Related: https://github.com/expo/expo/issues/15622#issuecomment-997141629