### PR TITLE
fix: Fix type of `YGNodeConstRef` for latest react-native version

### DIFF
--- a/ios/JBBaseTextShadowView.m
+++ b/ios/JBBaseTextShadowView.m
@@ -14,7 +14,7 @@
 
 NSString *const JBBaseTextShadowViewEmbeddedShadowViewAttributeName = @"JBBaseTextShadowViewEmbeddedShadowViewAttributeName";
 
-static void RCTInlineViewYogaNodeDirtied(YGNodeRef node)
+static void RCTInlineViewYogaNodeDirtied(YGNodeConstRef node)
 {
   // An inline view (a view nested inside of a text node) does not have a parent
   // in the Yoga tree. Consequently, we have to manually propagate the inline

--- a/ios/JBTextShadowView.m
+++ b/ios/JBTextShadowView.m
@@ -385,7 +385,7 @@
   return size.height + maximumDescender;
 }
 
-static YGSize RCTTextShadowViewMeasure(YGNodeRef node, float width, YGMeasureMode widthMode, float height, YGMeasureMode heightMode)
+static YGSize RCTTextShadowViewMeasure(YGNodeConstRef node, float width, YGMeasureMode widthMode, float height, YGMeasureMode heightMode)
 {
   CGSize maximumSize = (CGSize){
     widthMode == YGMeasureModeUndefined ? CGFLOAT_MAX : RCTCoreGraphicsFloatFromYogaFloat(width),
@@ -422,7 +422,7 @@ static YGSize RCTTextShadowViewMeasure(YGNodeRef node, float width, YGMeasureMod
   };
 }
 
-static float RCTTextShadowViewBaseline(YGNodeRef node, const float width, const float height)
+static float RCTTextShadowViewBaseline(YGNodeConstRef node, const float width, const float height)
 {
   JBTextShadowView *shadowTextView = (__bridge JBTextShadowView *)YGNodeGetContext(node);
 


### PR DESCRIPTION
In latest react-native, the type of `node` has been changed from `YGNodeRef` to `YGNodeConstRef`. Just a const modifier.

I think this even is non-breaking, because non-const to const is implicit, other way around would not work (hence the build error).