### PR TITLE
fix: removing touchableGetInitialState to fix rn 0.74 issue on ios

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ A fork of React Native's `<Text/>` component that supports Animated Values as te
     <th>RN Version</th>
   </tr>
   <tr>
+    <td> ^0.12.0</td>
+    <td> ^0.74.0</td>
+  </tr>
+  <tr>
     <td> ^0.11.0</td>
     <td> ^0.71.7</td>
   </tr>

--- a/src/AnimateableText.tsx
+++ b/src/AnimateableText.tsx
@@ -107,7 +107,6 @@ class TouchableText extends React.Component<AnimateableTextProps, State> {
   touchableHandleResponderTerminationRequest?: () => boolean;
 
   state = {
-    ...Touchable.Mixin.touchableGetInitialState(),
     isHighlighted: false,
     createResponderHandlers: this._createResponseHandlers.bind(this),
     responseHandlers: null,
@@ -131,7 +130,6 @@ class TouchableText extends React.Component<AnimateableTextProps, State> {
     if (isTouchable(props)) {
       props = {
         ...props,
-        ...this.state.responseHandlers,
         isHighlighted: this.state.isHighlighted,
       };
     }


### PR DESCRIPTION
Following the discussion in GitHub issue #46 (specifically, [comment #2073170951](https://github.com/axelra-ag/react-native-animateable-text/issues/46#issuecomment-2073170951) ), this pull request proposes the removal of the `touchableGetInitialState` method. While it's uncertain if this is the optimal solution for the issue raised in React 0.74, but I hope this pr to be somewhat helpful


I tired to test the code but got couple of errors locally 😓 , but at least I made sure types are correct XD


**One important note, this [issue](https://github.com/axelra-ag/react-native-animateable-text/issues/47) is also related to RN 0.74**