### PR TITLE
fix: replace ReadableNativeMap with MapBuffer to run on rn 0.75

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ A fork of React Native's `<Text/>` component that supports Animated Values as te
     <th>RN Version</th>
   </tr>
   <tr>
+    <td> ^0.13.0</td>
+    <td> ^0.75.0</td>
+  </tr>
+  <tr>
     <td> ^0.12.0</td>
     <td> ^0.74.0</td>
   </tr>


### PR DESCRIPTION
Fixing android [issue](https://github.com/axelra-ag/react-native-animateable-text/issues/52) that occured in RN 0.75

From my understanding with the latest release of react native `ReadableNativeMap` was replaced with  `MapBuffer` I used the current implementation of [textManager](https://github.com/facebook/react-native/blob/6cfe51ded006e55617a6f4f2587ca2026306c58d/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.java) to update to the new type, I did a patch for this fix on my own project to test the android build and things worked 